### PR TITLE
query

### DIFF
--- a/expression-js/src/datasource.rs
+++ b/expression-js/src/datasource.rs
@@ -1,13 +1,17 @@
+use crate::{
+    context::js_value_to_object,
+    context::value_to_js_object
+};
+use expression::Object;
 use std::rc::Rc;
 use wasm_bindgen::{
+    prelude::*,
     JsValue,
     UnwrapThrowExt,
-    prelude::*
+    convert::FromWasmAbi,
+    convert::IntoWasmAbi,
+    __rt::WasmRefCell
 };
-use wasm_bindgen::__rt::WasmRefCell;
-use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi};
-use expression::{Column, ManualError, Object};
-use crate::context::{js_value_to_object, value_to_js_object};
 
 #[wasm_bindgen(js_name=Address)]
 pub struct Address(expression::Address);
@@ -50,7 +54,7 @@ const DATA_SOURCE_CONFIG: &'static str = r#"
 
 #[wasm_bindgen(js_name=DataSource)]
 pub struct DataSource {
-    query: js_sys::Function,
+    query_handler: js_sys::Function,
 
     pub(crate) cx: Rc<WasmRefCell<Object>>
 }
@@ -59,41 +63,21 @@ pub struct DataSource {
 impl DataSource {
     #[wasm_bindgen(constructor)]
     pub fn new(config: JsValue) -> crate::DataSource {
-        let query = js_sys::Function::from(js_sys::Reflect::get(&config, &JsValue::from_str("query"))
-            .unwrap_throw());
-
         crate::DataSource {
-            query,
+            query_handler: js_sys::Function::from(js_sys::Reflect::get(&config, &JsValue::from_str("query"))
+                .unwrap_throw()),
 
             cx: Rc::new(WasmRefCell::new(Object::Nothing))
         }
     }
 }
 
-#[wasm_bindgen]
-pub struct RowWrapper(js_sys::Object);
-
-impl expression::Row for crate::RowWrapper {
-    #[allow(refining_impl_trait)]
-    fn fields(&self) -> impl Iterator<Item=String> + Clone {
-        js_sys::Object::keys(&self.0).into_iter()
-            .filter(|i| i.is_string())
-            .flat_map(|v| v.as_string())
-    }
-
-    fn get(&self, field: &str) -> Option<expression::Object> {
-        js_sys::Reflect::get(&self.0, &JsValue::from_str(field)).ok()
-            .and_then(|i| match i {
-                i if i.is_string() => Some(expression::Object::String(i.as_string()?)),
-                i if i.as_f64().is_some() => Some(expression::Object::Number(i.as_f64()?)),
-                _ => Some(expression::Object::Nothing)
-            })
-    }
-}
-
 impl expression::DataSource for DataSource {
     fn query(&self, query: impl AsRef<str>) -> Option<Object> {
-        match self.query.call1(&JsValue::null(), &JsValue::from_str(query.as_ref())) {
+        let cx = value_to_js_object(self.cx.borrow().clone())
+            .unwrap_or(JsValue::null());
+
+        match self.query_handler.call2(&JsValue::null(), &cx, &JsValue::from_str(query.as_ref())) {
             Ok(value) => Some(js_value_to_object(value)?),
             Err(_) => None
         }

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -218,36 +218,6 @@ where
         self.operators.insert(operator.symbol.clone(), operator);
     }
 
-    // pub fn resolve_name(&self, name: String) -> Result<Object> {
-    //     let mut chain = name.split('.');
-    //
-    //     'outer: {
-    //         if let Some(obj) = chain.next().and_then(|key| self.globals.get(key)) {
-    //             let mut object = obj;
-    //
-    //             while let Some(next) = chain.next() {
-    //                 match object {
-    //                     Object::AssociativeArray(arr) => if let Some(obj) = arr.get(next) {
-    //                         object = obj;
-    //                     } else {
-    //                         break 'outer;
-    //                     },
-    //                     Object::List(list) => if let Ok(Some(obj)) = next.parse::<usize>().map(|a| list.get(a)) {
-    //                         object = obj
-    //                     } else {
-    //                         break 'outer;
-    //                     },
-    //                     _ => break 'outer,
-    //                 }
-    //             }
-    //
-    //             return Ok(object.clone());
-    //         }
-    //     }
-    //
-    //     Err(ManualError::NoSuchValue(name.clone()).into())
-    // }
-
     pub fn call_object(&self, object: Object, arguments: &[Object]) -> Result<Object> {
         if let Object::Function(obj) = object {
             obj(arguments.iter().cloned().collect())
@@ -279,8 +249,8 @@ where
                     .cloned()
                     .ok_or(ManualError::NoSuchValue(name.clone()).into()),
 
-                Literal::Address(address) => self.query(&address.query)
-                    .ok_or(ManualError::EmptyResultSet(address.query).into())
+                Literal::Address(address) => Ok(self.query(&address.query)
+                    .unwrap_or(Object::Nothing)),
             }
 
             Value::Call(Call { name, arguments }) => self.call_object(self.evaluate_value(*name)?, &arguments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ pub mod error;
 pub mod parse;
 pub mod eval;
 mod vec;
-// mod hashmap;
 
 pub use crate::error::*;
 pub use crate::eval::*;
@@ -19,7 +18,7 @@ pub use crate::parse::literal::Address;
 pub use crate::parse::literal::Column;
 
 /// # Data Source
-/// A datasource may be thought of as a self-contained table.
+/// A datasource which responds to queries.
 /// It may produce its values either by reading them from a data source or computing them directly.
 ///
 /// ## Examples of where data sources are useful


### PR DESCRIPTION
Refactor to arbitrary query formats